### PR TITLE
Fixes for the 1.7.9 version of InfinitePlots

### DIFF
--- a/src/main/java/uk/co/jacekk/bukkit/infiniteplots/command/InfoCommandExecutor.java
+++ b/src/main/java/uk/co/jacekk/bukkit/infiniteplots/command/InfoCommandExecutor.java
@@ -48,12 +48,12 @@ public class InfoCommandExecutor extends BaseCommandExecutor<InfinitePlots> {
 		
 		player.sendMessage(ChatColor.YELLOW + "Plot Information");
 		
-		player.sendMessage(ChatColor.BLUE + "Owner: " + ChatColor.RESET + plot.getAdmin());
+		player.sendMessage(ChatColor.BLUE + "Owner: " + ChatColor.RESET + plot.getAdmin().getName());
 		player.sendMessage(ChatColor.BLUE + "Name: " + ChatColor.RESET + plot.getName());
 		player.sendMessage(ChatColor.BLUE + "Location: " + ChatColor.RESET + plot.getLocation().getX() + ", " + plot.getLocation().getZ());
 		
 		if (!plot.getBuilders().isEmpty()){
-			player.sendMessage(ChatColor.LIGHT_PURPLE + "Builders: " + ChatColor.RESET + ListUtils.implode(", ", plot.getBuilders()));
+			player.sendMessage(ChatColor.LIGHT_PURPLE + "Builders: " + ChatColor.RESET + ListUtils.implode(", ", plot.getBuilderNames()));
 		}
 		
 		StringBuilder flags = new StringBuilder();

--- a/src/main/java/uk/co/jacekk/bukkit/infiniteplots/plot/Plot.java
+++ b/src/main/java/uk/co/jacekk/bukkit/infiniteplots/plot/Plot.java
@@ -159,11 +159,13 @@ public class Plot extends BaseObject<InfinitePlots> {
 		for (String id : ids){
 			OfflinePlayer player = plugin.getServer().getOfflinePlayer(UUID.fromString(id));
 			String name = null;
-			if (player != null)
+			if (player != null){
 				name = player.getName();
-			if (name == null) {
+			}
+				
+			if (name == null){
 				players.add(id);
-			} else {
+			}else{
 				players.add(name);
 			}
 		}
@@ -248,7 +250,7 @@ public class Plot extends BaseObject<InfinitePlots> {
 	 */
 	protected List<String> getStringList(Collection<OfflinePlayer> playerList) {
 		List<String> uuids = new ArrayList<String>();
-		for (OfflinePlayer player: playerList) {
+		for (OfflinePlayer player: playerList){
 			uuids.add(player.getUniqueId().toString());
 		}
 		return uuids;

--- a/src/main/java/uk/co/jacekk/bukkit/infiniteplots/plot/Plot.java
+++ b/src/main/java/uk/co/jacekk/bukkit/infiniteplots/plot/Plot.java
@@ -3,6 +3,7 @@ package uk.co.jacekk.bukkit.infiniteplots.plot;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
@@ -132,7 +133,7 @@ public class Plot extends BaseObject<InfinitePlots> {
 	 * Gets all of the players (not including the plot admin) that are allowed
 	 * to build in this plot.
 	 * 
-	 * @return The list of player names.
+	 * @return The list of players.
 	 */
 	public List<OfflinePlayer> getBuilders(){
 		List<String> ids = this.config.getStringList(PlotConfig.AUTH_BUILDER_UUIDS);
@@ -140,6 +141,28 @@ public class Plot extends BaseObject<InfinitePlots> {
 		
 		for (String id : ids){
 			players.add(plugin.getServer().getOfflinePlayer(UUID.fromString(id)));
+		}
+		
+		return players;
+	}
+	
+	/**
+	 * Gets the names of all of the players (not including the plot admin) that 
+	 * are allowed to build in this plot.
+	 * 
+	 * @return The list of player names.
+	 */
+	public List<String> getBuilderNames(){
+		List<String> ids = this.config.getStringList(PlotConfig.AUTH_BUILDER_UUIDS);
+		List<String> players = new ArrayList<String>(ids.size());
+		
+		for (String id : ids){
+			String name = plugin.getServer().getOfflinePlayer(UUID.fromString(id)).getName();
+			if (name == null) {
+				players.add(id);
+			} else {
+				players.add(name);
+			}
 		}
 		
 		return players;
@@ -215,6 +238,20 @@ public class Plot extends BaseObject<InfinitePlots> {
 	}
 	
 	/**
+	 * Returns a list of strings representing the list of player UUIDs.
+	 * 
+	 * @param playerList 
+	 * @return A list of UUIDs represented as strings
+	 */
+	protected List<String> getStringList(Collection<OfflinePlayer> playerList) {
+		List<String> uuids = new ArrayList<String>();
+		for (OfflinePlayer player: playerList) {
+			uuids.add(player.getUniqueId().toString());
+		}
+		return uuids;
+	}
+	
+	/**
 	 * Adds a builder to this plot.
 	 * 
 	 * @param playerName The name of the player to add.
@@ -223,7 +260,7 @@ public class Plot extends BaseObject<InfinitePlots> {
 		List<OfflinePlayer> builders = this.getBuilders();
 		builders.add(player);
 		
-		this.config.set(PlotConfig.AUTH_BUILDER_UUIDS, builders);
+		this.config.set(PlotConfig.AUTH_BUILDER_UUIDS, getStringList(builders));
 	}
 	
 	/**
@@ -235,7 +272,7 @@ public class Plot extends BaseObject<InfinitePlots> {
 		List<OfflinePlayer> builders = this.getBuilders();
 		builders.remove(player);
 		
-		this.config.set(PlotConfig.AUTH_BUILDER_UUIDS, builders);
+		this.config.set(PlotConfig.AUTH_BUILDER_UUIDS, getStringList(builders));
 	}
 	
 	/**

--- a/src/main/java/uk/co/jacekk/bukkit/infiniteplots/plot/Plot.java
+++ b/src/main/java/uk/co/jacekk/bukkit/infiniteplots/plot/Plot.java
@@ -157,7 +157,10 @@ public class Plot extends BaseObject<InfinitePlots> {
 		List<String> players = new ArrayList<String>(ids.size());
 		
 		for (String id : ids){
-			String name = plugin.getServer().getOfflinePlayer(UUID.fromString(id)).getName();
+			OfflinePlayer player = plugin.getServer().getOfflinePlayer(UUID.fromString(id));
+			String name = null;
+			if (player != null)
+				name = player.getName();
 			if (name == null) {
 				players.add(id);
 			} else {

--- a/src/main/java/uk/co/jacekk/bukkit/infiniteplots/plot/PlotLocation.java
+++ b/src/main/java/uk/co/jacekk/bukkit/infiniteplots/plot/PlotLocation.java
@@ -53,6 +53,17 @@ public class PlotLocation {
 	}
 	
 	/**
+	 * Returns whether a given location is in a plot world
+	 * 
+	 * @param worldLocation The {@link Location} in block space.
+	 * @return true if the given location is in a plot world
+	 */
+	public static boolean isInPlotWorld(Location worldLocation) {
+		ChunkGenerator generator = worldLocation.getWorld().getGenerator();
+		return generator instanceof PlotsGenerator;
+	}
+	
+	/**
 	 * Creates a new PlotLocation based on the location in block space.
 	 * 
 	 * @param worldLocation The {@link Location} in block space.

--- a/src/main/java/uk/co/jacekk/bukkit/infiniteplots/plot/PlotManager.java
+++ b/src/main/java/uk/co/jacekk/bukkit/infiniteplots/plot/PlotManager.java
@@ -65,12 +65,12 @@ public class PlotManager extends BaseObject<InfinitePlots> {
 						
 						try{
 							Map<String, UUID> map = (new UUIDFetcher(builderNames)).call();
-							List<String> builderUuids = new ArrayList<String>();
+							List<String> uuids = new ArrayList<String>();
 							for (UUID uuid: map.values()) {
-								builderUuids.add(uuid.toString());
+								uuids.add(uuid.toString());
 							}
 							
-							plotConfig.set(PlotConfig.AUTH_BUILDER_UUIDS, builderUuids);
+							plotConfig.set(PlotConfig.AUTH_BUILDER_UUIDS, uuids);
 							plotConfig.set(PlotConfig.AUTH_BUILDER_NAMES, Arrays.asList());
 						}catch (Exception e){
 							plugin.log.warn("Failed to fetch UUID for plot builders: " + e.getMessage());

--- a/src/main/java/uk/co/jacekk/bukkit/infiniteplots/plot/PlotManager.java
+++ b/src/main/java/uk/co/jacekk/bukkit/infiniteplots/plot/PlotManager.java
@@ -65,7 +65,12 @@ public class PlotManager extends BaseObject<InfinitePlots> {
 						
 						try{
 							Map<String, UUID> map = (new UUIDFetcher(builderNames)).call();
-							plotConfig.set(PlotConfig.AUTH_BUILDER_UUIDS, map.values());
+							List<String> builderUuids = new ArrayList<String>();
+							for (UUID uuid: map.values()) {
+								builderUuids.add(uuid.toString());
+							}
+							
+							plotConfig.set(PlotConfig.AUTH_BUILDER_UUIDS, builderUuids);
 							plotConfig.set(PlotConfig.AUTH_BUILDER_NAMES, Arrays.asList());
 						}catch (Exception e){
 							plugin.log.warn("Failed to fetch UUID for plot builders: " + e.getMessage());

--- a/src/main/java/uk/co/jacekk/bukkit/infiniteplots/plot/PlotManager.java
+++ b/src/main/java/uk/co/jacekk/bukkit/infiniteplots/plot/PlotManager.java
@@ -66,7 +66,7 @@ public class PlotManager extends BaseObject<InfinitePlots> {
 						try{
 							Map<String, UUID> map = (new UUIDFetcher(builderNames)).call();
 							List<String> uuids = new ArrayList<String>();
-							for (UUID uuid: map.values()) {
+							for (UUID uuid: map.values()){
 								uuids.add(uuid.toString());
 							}
 							

--- a/src/main/java/uk/co/jacekk/bukkit/infiniteplots/protection/BuildListener.java
+++ b/src/main/java/uk/co/jacekk/bukkit/infiniteplots/protection/BuildListener.java
@@ -86,8 +86,10 @@ public class BuildListener extends BaseListener<InfinitePlots> {
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onPistonExtend(BlockPistonExtendEvent event){
 		Block piston = event.getBlock();
-		if (!PlotLocation.isInPlotWorld(piston.getLocation()))
+		if (!PlotLocation.isInPlotWorld(piston.getLocation())){
 			return;
+		}
+			
 		Plot plot = plugin.getPlotManager().getPlotAt(PlotLocation.fromWorldLocation(piston.getLocation()));
 		
 		if (plot == null){

--- a/src/main/java/uk/co/jacekk/bukkit/infiniteplots/protection/BuildListener.java
+++ b/src/main/java/uk/co/jacekk/bukkit/infiniteplots/protection/BuildListener.java
@@ -86,6 +86,8 @@ public class BuildListener extends BaseListener<InfinitePlots> {
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onPistonExtend(BlockPistonExtendEvent event){
 		Block piston = event.getBlock();
+		if (!PlotLocation.isInPlotWorld(piston.getLocation()))
+			return;
 		Plot plot = plugin.getPlotManager().getPlotAt(PlotLocation.fromWorldLocation(piston.getLocation()));
 		
 		if (plot == null){


### PR DESCRIPTION
Fixes issue #55 (exception on piston movement on a non-plot world)
Fixes importing builder lists into the new UUID format (used to corrupt the plot)
/iplot info now displays again a list of users for plot admins and builders, and not some weird technicalese
